### PR TITLE
Fix broken etcd rest api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ If you're looking for a new feature, or are interested in contributing, we'd lov
 	
 ## Additional Resources
 
-* [Etcd REST API](https://github.com/coreos/etcd/blob/master/Documentation/api.md)
+* [Etcd REST API](https://github.com/coreos/etcd/blob/master/Documentation/v2/api.md)
 * [etcd-rest](https://github.com/cdancy/etcd-rest)


### PR DESCRIPTION
etcd after releasing version 3 modified their existing v2 api location